### PR TITLE
Update actions versions in the CI workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,10 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Artifact cache
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@v2
+
+      - name: Remove binaries from cache
+        run: rm -vf target/wasm32-unknown-unknown/release/*.wasm
 
       - name: Install nightly toolchain
         uses: actions-rs/toolchain@v1
@@ -60,7 +63,7 @@ jobs:
         uses: actions/download-artifact@v3
 
       - name: Delete previous release
-        uses: dev-drprasad/delete-tag-and-release@v0.1.3
+        uses: dev-drprasad/delete-tag-and-release@v0.2.0
         with:
           delete_release: true
           tag_name: build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,10 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Cache
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@v2
+
+      - name: Remove binaries from cache
+        run: rm -vf target/wasm32-unknown-unknown/release/*.wasm
 
       - name: Install nightly toolchain
         uses: actions-rs/toolchain@v1


### PR DESCRIPTION
- Resolves #8
- Removes old `*.wasm` binaries from cache