### PR TITLE
refactor: remove obsolete commands and CI steps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,6 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  NIGHTLY_TOOLCHAIN_VERSION: ${{ secrets.NIGHTLY_TOOLCHAIN_VERSION }}
 
 jobs:
   build:
@@ -26,13 +25,6 @@ jobs:
 
       - name: Remove binaries from cache
         run: rm -vfr target/wasm32-unknown-unknown/*
-
-      - name: Show specific nightly version
-        if: ${{ env.NIGHTLY_TOOLCHAIN_VERSION != '' }}
-        run: echo $NIGHTLY_TOOLCHAIN_VERSION | sed 's/-/ - /g'
-
-      - name: Install specific nightly toolchain
-        run: make init
 
       - name: Check fmt
         run: make fmt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,6 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  NIGHTLY_TOOLCHAIN_VERSION: ${{ secrets.NIGHTLY_TOOLCHAIN_VERSION }}
 
 jobs:
   prepare:
@@ -35,13 +34,6 @@ jobs:
 
       - name: Remove binaries from cache
         run: rm -vfr target/wasm32-unknown-unknown/*
-
-      - name: Show specific nightly version
-        if: ${{ env.NIGHTLY_TOOLCHAIN_VERSION != '' }}
-        run: echo $NIGHTLY_TOOLCHAIN_VERSION | sed 's/-/ - /g'
-
-      - name: Install specific nightly toolchain
-        run: make init
 
       - name: Build
         run: make build

--- a/Makefile
+++ b/Makefile
@@ -15,11 +15,6 @@ fmt-doc:
 	@echo ⚙️ Format the docs...
 	@cargo fmt -- --config wrap_comments=true,format_code_in_doc_comments=true
 
-init:
-	@echo ⚙️ Installing a toolchain \& a target...
-	@rustup toolchain install nightly --component clippy --component rustfmt
-	@rustup target add wasm32-unknown-unknown --toolchain nightly
-
 lint:
 	@echo ⚙️ Running the linter...
 	@cargo clippy --workspace --all-targets -- -D warnings

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-.PHONY: all build fmt fmt-doc init lint pre-commit test full-test deps
+.PHONY: all build fmt fmt-doc lint pre-commit test full-test deps
 
-all: init build test
+all: build test
 
 build:
 	@echo ⚙️ Building a release...

--- a/README.md
+++ b/README.md
@@ -47,19 +47,6 @@ Raw, optimized, and meta WASM binaries can be found in the [Releases section](ht
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 ```
 
-### ⚒️ Add specific toolchains
-
-```shell
-rustup toolchain add nightly
-rustup target add wasm32-unknown-unknown --toolchain nightly
-```
-
-... or ...
-
-```shell
-make init
-```
-
 ### 🏗️ Build
 
 ```shell


### PR DESCRIPTION
- Remove `make init` command
- Remove obsolete CI steps related to the nightly toolchain pinning